### PR TITLE
Missing Secrets in local copy of files on NAS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,15 @@ jobs:
         run: |
           ssh-keyscan -t rsa ${{ secrets.NAS_IP }} >> ~/.ssh/known_hosts
 
+      #STEP - Copy Content locally
+      #===========================
+      #Copy the contents locally for re-use outside pipelines etc           
+      - name: Copy Content Locally
+        run: |
+          #cleanup working files
+          rm ./wg0.conf
+          scp -r ./* ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks
+
       # FIX - Add ssh config for Docker
       # =================================
       # Add the following ssh configs as per docker suggestion https://docs.docker.com/engine/security/protect-access/#ssh-tips          
@@ -124,15 +133,6 @@ jobs:
               cd ..
             fi
           done
-
-      #STEP - Copy Content locally
-      #===========================
-      #Copy the contents locally for re-use outside pipelines etc           
-      - name: Copy Content Locally
-        run: |
-          #cleanup working files
-          rm ./wg0.conf
-          scp -r ./* ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks
 
       # STEP - Discconect from Wireguard
       # ================================


### PR DESCRIPTION
During the action. The working copy of the files that include the secrets are copied locally to the NAS.

For some reason the copies on the NAS the secrets are showing up empty in the .env files