### PR TITLE
Improvements: validation fix, deploy hardening, typos & consistency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# We pin third-party (and even first-party) GitHub Actions to commit SHAs to
+# protect against tag-rewrite supply-chain attacks. Dependabot watches each
+# pinned action and opens a PR when a new version is released, with the
+# resolved SHA already in place — so upgrades stay simple while pinning
+# stays strict.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: scope
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,8 @@ jobs:
       # Install and connect to Wireguard
       - name: Connect to Wireguard
         run: |
-          sudo apt install resolvconf
-          sudo apt install wireguard
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends resolvconf wireguard
           echo "${{ secrets.WG_CONFIG_FILE }}" > wg0.conf
           sudo chmod 600 wg0.conf
           sudo wg-quick up ./wg0.conf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,12 +144,20 @@ jobs:
 
       #STEP - Copy Content locally
       #===========================
-      #Copy the contents locally for re-use outside pipelines etc           
+      #Mirror repo content into /config/stacks on the NAS so the local
+      #backup/dockhand tooling can read the same files the workflow just
+      #deployed. Uses rsync --delete so retired stack directories (e.g.
+      #'ai/') are removed on the NAS, not orphaned forever. Excludes
+      #repo-meta dirs (.git, .github, .vscode) and the wireguard config
+      #we used for this run (belt-and-braces; we already rm'd it).
       - name: Copy Content Locally
         run: |
           #cleanup working files
           rm ./wg0.conf
-          scp -r ./* ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks
+          rsync -avz --delete \
+            --exclude='.git' --exclude='.github' --exclude='.vscode' \
+            --exclude='wg0.conf' \
+            ./ ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks/
 
       # STEP - Discconect from Wireguard
       # ================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,20 +77,19 @@ jobs:
 
        # STEP - Add SSH Keys
       # ====================
-      # Add SSH Key used to connect to NAS
+      # Add SSH Key used to connect to NAS, and pin the NAS's host keys
+      # so we refuse to talk to anything else (replaces the previous
+      # trust-on-first-use ssh-keyscan step, which would silently accept
+      # whatever host key the network handed us each run).
+      # NOTE: If the NAS is ever rebuilt and its /etc/ssh/ssh_host_* keys
+      # regenerated, update the NAS_HOST_KEY secret (environment 'nas')
+      # with the new fingerprints or this step will refuse to connect.
       - name: Add SSH Key
         uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           # SSH private key
           key: ${{secrets.SSH_PRIVATE_KEY}}
-          known_hosts: 'placeholder'
-
-      # STEP - Setup SSH known_host entry
-      # =================================
-      # Add NAS SSH host key to known_hosts file
-      - name: Add SSH known_host entry
-        run: |
-          ssh-keyscan -t rsa ${{ secrets.NAS_IP }} >> ~/.ssh/known_hosts
+          known_hosts: ${{ secrets.NAS_HOST_KEY }}
 
       # STEP - Configure ssh  for Docker
       # ================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,13 @@ jobs:
       # ====================
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check-out Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # STEP - Connect to Azure
       # =======================
       # This step is used to connect to Azure to allow reading of Azure KeyVault in later step
       - name: Connect to Azure
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           creds: ${{ secrets.AZURE_SPN_CREDENTIALS }}
 
@@ -43,7 +43,7 @@ jobs:
       # =================================
       # Get Secrets from Azure KeyVault and store them as env variables as secrets for use later   
       - name: Get Azure KeyVault Secrets
-        uses: copdips/get-azure-keyvault-secrets-action@v1
+        uses: copdips/get-azure-keyvault-secrets-action@b823bc9a2bc24c45a58ba09dc234cf4be05f38d7 # v1
         with:
           keyvault: ${{ secrets.AZURE_KEYVAULT_NAME }}
           
@@ -51,7 +51,7 @@ jobs:
       # ===================================
       # Replaces tokens (e.g. #{TOKEN}#) in files with the matching environment variable of the same token name           
       - name: Replace tokens in .env files
-        uses: cschleiden/replace-tokens@v1
+        uses: cschleiden/replace-tokens@63252851d87eb5cb853019ba8538b5c51813779d # v1
         with:
           files: '["**/.env"]'
 
@@ -79,7 +79,7 @@ jobs:
       # ====================
       # Add SSH Key used to connect to NAS
       - name: Add SSH Key
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           # SSH private key
           key: ${{secrets.SSH_PRIVATE_KEY}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,17 +120,28 @@ jobs:
 
       # STEP - Deploy Stacks
       # ====================
-      # Deploy docker stacks locally  
+      # Deploy docker stacks locally
       - name: Deploy Docker Stacks
         run: |
+          set -eo pipefail
+          failed=()
           for dir in */; do
-            if [ -f "${dir}docker-compose.yml" ]; then
-              cd "$dir"
-              echo "Deploying ${PWD##*/} stack"
-              docker compose up -d
-              cd ..
+            [ -f "${dir}docker-compose.yml" ] || continue
+            stack="${dir%/}"
+            echo "::group::Deploying ${stack}"
+            if ( cd "$dir" && docker compose up -d ); then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error title=Stack deploy failed::${stack} failed to deploy"
+              failed+=("$stack")
             fi
           done
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::${#failed[@]} stack(s) failed: ${failed[*]}"
+            exit 1
+          fi
+          echo "All stacks deployed successfully"
 
       #STEP - Copy Content locally
       #===========================

--- a/.github/workflows/tests/dockercompose.Tests.ps1
+++ b/.github/workflows/tests/dockercompose.Tests.ps1
@@ -1,21 +1,27 @@
-$TestCases = Get-ChildItem -Recurse -Filter 'docker-compose.yml'
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
-Describe 'Validate Docker Stack' {
+# Validates every docker-compose.yml in the repo by running
+# `docker compose config -q` and checking the result is clean.
+#
+# A passing test means: exit code 0 AND no output on stdout/stderr.
+# We deliberately check stderr too because docker emits WARN[0000]
+# lines when a compose file references an env var that isn't defined
+# in the stack's .env file. Tokenized placeholders like `#{DOMAIN}#`
+# are valid values (they get substituted at deploy time), so they
+# don't trigger warnings — only genuinely missing variables do.
 
-    It " <_.Directory.Name> - should have a valid <_.Name>" -ForEach $TestCases {
-        try {
-            Invoke-Expression "docker compose -f '$($_.fullName)' config -q 2>tmp.dockercompose.log"
-            $result = Get-Content "tmp.dockercompose.log"
-            
-            # Check result is empty, if not we have an error
-            $result | Should -BeNullOrEmpt
-        }
-        Catch
-        {
-            $errorMessage = $_.Exception.Message
-            Write-Host "Error validating $($_.FullName): $errorMessage"
-            throw $_.Exception
-        }
-        
+$composeFiles = Get-ChildItem -Recurse -Filter 'docker-compose.yml' -File
+
+Describe 'Docker Compose stack validation' {
+
+    It 'Stack <_.Directory.Name> is valid' -ForEach $composeFiles {
+        $composePath = $_.FullName
+
+        $output = & docker compose -f $composePath config -q 2>&1
+        $exitCode = $LASTEXITCODE
+        $outputText = if ($output) { ($output | Out-String).Trim() } else { '' }
+
+        $exitCode | Should -Be 0 -Because "docker compose exited $exitCode for $composePath`n--- output ---`n$outputText"
+        $outputText | Should -BeNullOrEmpty -Because "docker compose produced output for $composePath`n--- output ---`n$outputText"
     }
 }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,13 +29,13 @@ jobs:
       # ====================
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check-out Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # STEP - Validate docker stacks
       # =============================
       # Run a validation check on all the docker-compose.yml files for the different stacks
       - name: Validate Docker Stacks
-        uses: zyborg/pester-tests-report@v1
+        uses: zyborg/pester-tests-report@bb711b31e93f78f7423086d57f81928325829765 # v1
         with:
           include_paths: .github/workflows/tests
           tests_fail_step: true
@@ -47,7 +47,7 @@ jobs:
       # ================================
       # Run a security check on everything for potential security issues
       - name: Run Microsoft Security DevOps
-        uses: microsoft/security-devops-action@v1
+        uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0 # v1.12.0
         id: msdo
         with:
           tools: checkov, trivy
@@ -56,6 +56,6 @@ jobs:
       # ===============================================
       # Upload the results of the Microsoft Security DevOps to the repo
       - name: Upload results to Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -25,7 +25,7 @@ jobs:
     
     steps:
    
-      # STEP - Check-out Rep
+      # STEP - Check-out Repo
       # ====================
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check-out Repo
@@ -38,12 +38,9 @@ jobs:
         uses: zyborg/pester-tests-report@v1
         with:
           include_paths: .github/workflows/tests
-          #exclude_paths:
-          #exclude_tags: skip_ci
           tests_fail_step: true
           report_name: Docker Stacks Validation
           report_title: Docker Stacks Validation
-          result_value: Passed
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # STEP - Microsoft Security DevOps

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Editor/IDE per-machine settings
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Local WireGuard / SSH artifacts (never commit)
+wg0.conf
+*.pem
+id_rsa
+id_rsa.pub
+id_ed25519
+id_ed25519.pub
+
+# Pester scratch (from the old broken validation test)
+tmp.dockercompose.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "python.analysis.extraPaths": [
-        "c:\\Users\\o\\.vscode\\extensions\\ms-security.ms-sentinel-1.1.1\\python",
-        "c:\\Users\\o\\.vscode\\extensions\\ms-security.ms-sentinel-1.2.0\\python",
-        "c:\\Users\\o\\.vscode\\extensions\\ms-security.ms-sentinel-1.3.0\\python",
-        "c:\\Users\\o\\.vscode\\extensions\\ms-security.ms-sentinel-2.0.0\\python",
-        "c:\\Users\\o\\.vscode\\extensions\\ms-security.ms-sentinel-2.2.0\\python"
-    ]
-}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ DOCKERDIR=/docker/${COMPOSE_PROJECT_NAME}
 DOMAIN=#{DOMAIN}#
 
 #Stack Specific Variables
-MYSECRET: #{MYSECRET}#
+MYSECRET=#{MYSECRET}#
 
 ```
 > [!TIP]
@@ -84,9 +84,9 @@ services:
     - traefik.enable=true
     - traefik.http.services.{containername}.loadbalancer.server.port={port}
     # Traefik - Router - HTTPS
-    - traefik.http.routers.{containername}.rule=Host(`autogen.${DOMAIN}`)
+    - traefik.http.routers.{containername}.rule=Host(`{containername}.${DOMAIN}`)
     - traefik.http.routers.{containername}.entryPoints=websecure
-    - traefik.http.routers.autogen.middlewares=Real-IP@file, Headers@file
+    - traefik.http.routers.{containername}.middlewares=Real-IP@file, Headers@file
 
 #Shared Networks between containers
 networks:

--- a/games/docker-compose.yml
+++ b/games/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     networks:
       games:
         ipv4_address: 10.1.20.3
+        # NOTE: do not change this MAC address — AMP's licence is bound to it.
         mac_address: 02:42:AC:C1:3B:68 # Please see the README about this field.
     volumes:
       - ${DOCKERDIR}/amp:/home/amp/.ampdata

--- a/media/docker-compose.yml
+++ b/media/docker-compose.yml
@@ -164,11 +164,11 @@ services:
     labels:
     # Traefik - Service
     - traefik.enable=true
-    - traefik.http.services.Wrapperr.loadbalancer.server.port=8282
+    - traefik.http.services.wrapperr.loadbalancer.server.port=8282
     # Traefik - Router - HTTPS
-    - traefik.http.routers.Wrapperr.rule=Host(`wrapperr.${DOMAIN}`)
-    - traefik.http.routers.Wrapperr.entryPoints=websecure
-    - traefik.http.routers.Wrapperr.middlewares=Real-IP@file, Headers@file
+    - traefik.http.routers.wrapperr.rule=Host(`wrapperr.${DOMAIN}`)
+    - traefik.http.routers.wrapperr.entryPoints=websecure
+    - traefik.http.routers.wrapperr.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
     - kuma.wrapperr.http.name=Wrapperr
     - kuma.wrapperr.http.url=https://wrapperr.${DOMAIN}
@@ -225,11 +225,11 @@ services:
     labels:
     # Traefik - Service
     - traefik.enable=true
-    - traefik.http.services.Tdarr.loadbalancer.server.port=8265
+    - traefik.http.services.tdarr.loadbalancer.server.port=8265
     # Traefik - Router - HTTPS
-    - traefik.http.routers.Tdarr.rule=Host(`tdarr.${DOMAIN}`)
-    - traefik.http.routers.Tdarr.entryPoints=websecure
-    - traefik.http.routers.Tdarr.middlewares=Real-IP@file, Headers@file
+    - traefik.http.routers.tdarr.rule=Host(`tdarr.${DOMAIN}`)
+    - traefik.http.routers.tdarr.entryPoints=websecure
+    - traefik.http.routers.tdarr.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
     - kuma.tdarr.http.name=Tdarr
     - kuma.tdarr.http.url=https://tdarr.${DOMAIN}
@@ -240,7 +240,7 @@ services:
     container_name: MusicAssistant
     hostname: musicassistant
     image: ghcr.io/music-assistant/server:latest
-    restart: unless-stopped
+    restart: always
     networks:
        IoT:
         ipv4_address: 10.1.11.101
@@ -288,11 +288,11 @@ services:
     labels:
     # Traefik - Service
     - traefik.enable=true
-    - traefik.http.services.FileBrowser.loadbalancer.server.port=80
+    - traefik.http.services.filebrowser.loadbalancer.server.port=80
     # Traefik - Router - HTTPS
-    - traefik.http.routers.FileBrowser.rule=Host(`media.${DOMAIN}`)
-    - traefik.http.routers.FileBrowser.entryPoints=websecure
-    - traefik.http.routers.FileBrowser.middlewares=Real-IP@file, Headers@file
+    - traefik.http.routers.filebrowser.rule=Host(`media.${DOMAIN}`)
+    - traefik.http.routers.filebrowser.entryPoints=websecure
+    - traefik.http.routers.filebrowser.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
     - kuma.filebrowser.http.name=FileBrowser
     - kuma.filebrowser.http.url=https://media.${DOMAIN}

--- a/media/docker-compose.yml
+++ b/media/docker-compose.yml
@@ -24,9 +24,9 @@ services:
     # Traefik - Service
     - traefik.enable=false
     # AutoKuma - Uptime Kuma Monitor
-    - kuma.overseerr.http.name=Plex
-    - kuma.overseerr.http.url=http://10.1.11.100:32400/identity
-    - kuma.overseerr.http.parent_name=media
+    - kuma.plex.http.name=Plex
+    - kuma.plex.http.url=http://10.1.11.100:32400/identity
+    - kuma.plex.http.parent_name=media
 
 
   seerr:
@@ -262,7 +262,7 @@ services:
     - traefik.http.routers.musicassistant.entryPoints=websecure
     - traefik.http.routers.musicassistant.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
-    - kuma.filebmusicassistantrowser.http.name=musicassistant
+    - kuma.musicassistant.http.name=Music Assistant
     - kuma.musicassistant.http.url=https://musicassistant.${DOMAIN}
     - kuma.musicassistant.http.headers=${KUMA_CFHEADERS}
     - kuma.musicassistant.http.parent_name=media

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - apparmor:unconfined
     volumes:
       - ${DOCKERDIR}/netdata/config:/etc/netdata
-      - ${DOCKERDIR}/netdata/lib:/varl/lib/netdata
+      - ${DOCKERDIR}/netdata/lib:/var/lib/netdata
       - ${DOCKERDIR}/netdata/cache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro

--- a/network/docker-compose.yml
+++ b/network/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     - traefik.http.services.adguardhome-sync.loadbalancer.server.port=8080
     # Traefik - Router - HTTPS
     - traefik.http.routers.adguardhome-sync.rule=Host(`adguard-sync.${DOMAIN}`)
-    - traefik.http.routers.speeadguardhome-syncdtest.entryPoints=websecure
+    - traefik.http.routers.adguardhome-sync.entryPoints=websecure
     - traefik.http.routers.adguardhome-sync.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
     - kuma.adguardsync.http.name=AdGuard Home Sync

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - --experimental.plugins.traefik-real-ip.modulename=github.com/soulbalz/traefik-real-ip
       - --experimental.plugins.traefik-real-ip.version=v1.0.3
       # Logging
-      - --log.level=DEBUG
+      - --log.level=INFO
       - --log.filePath=/var/log/traefik/traefik.log
       - --accesslog=true
       - --accesslog.filepath=/var/log/traefik/access.log


### PR DESCRIPTION
## Summary

A batch of small-to-medium improvements across the CI workflows, the deploy pipeline, and the compose stacks. Each commit does one focused thing so any single change can be reverted independently. All commits pass the validation workflow.

## What's in here

### CI / validation hardening
- **fix broken pester assertion in compose validation test** — the old test had a typo (`BeNullOrEmpt`) that meant the assertion never ran and the test reported failure-via-exception instead of actually validating compose files. Rewrote with strict assertions on both exit code and stderr, dropped the `Invoke-Expression` antipattern. Verified on a deliberately-broken throwaway branch that the new test catches real bugs.
- **clean up validation workflow** — removed an invalid `result_value: Passed` input that was generating a runner warning, dead commented-out config, and a typo in a step comment.
- **pin all github actions to commit SHAs + enable Dependabot** — mutable tags like `@v1` can be silently re-pointed to arbitrary code by the action owner. Pinning to SHAs locks each action to the exact version we vetted; Dependabot opens PRs when new versions are released with the resolved SHA already in place. No behaviour change today — pinned to current major-version SHAs.

### Deploy workflow hardening
- **fail loudly when a stack fails to deploy** — the previous loop had no `set -e` and no failure tracking, so a failed `docker compose up -d` was invisible and the workflow would report success even with broken stacks. Now: per-stack subshells, collected failures, `::group::` log folding, and `::error` annotations.
- **pin NAS SSH host keys instead of trust-on-first-use keyscan** — the old `ssh-keyscan -t rsa` step accepted whatever host key came back on every run. Now uses a `NAS_HOST_KEY` environment secret (rsa + ecdsa + ed25519) captured directly from the NAS and verified against the existing known_hosts.
- **use apt-get with proper scripting flags for wireguard install** — two stale `sudo apt install <pkg>` calls (`apt` is not stable for scripts and can prompt) replaced with one `apt-get update && apt-get install -y --no-install-recommends` transaction with `DEBIAN_FRONTEND=noninteractive`.
- **rsync --delete instead of scp -r for /config/stacks mirror** — `scp -r` only adds/updates, so retired stacks leak forever. `rsync --delete` makes `/config/stacks/` on the NAS a true mirror of the repo. Excludes `.git`, `.github`, `.vscode`, `wg0.conf` (belt-and-braces).

### Real bugs in the stacks
- **fix typos in compose files** — four real bugs:
  - `AdGuardHome-Sync`: typo'd Traefik router name (`speeadguardhome-syncdtest`) was preventing HTTPS entrypoint binding.
  - `MusicAssistant`: Kuma label key was a copy-paste collision with FileBrowser (`filebmusicassistantrowser`), creating an orphan monitor.
  - `Plex`: Kuma labels still referenced `overseerr.*` from before the Seerr migration, registering the Plex monitor under the wrong key.
  - `Netdata`: lib volume bind mount target was `/varl/` (typo) so history was never persisting; fixed to `/var/lib/netdata`.

### Consistency / hygiene
- **general cleanup: lowercase traefik labels, consistency, comments** — `Wrapperr`, `Tdarr`, and `FileBrowser` had Pascal-cased Traefik label keys; lowercased to match every other stack. Traefik log level `DEBUG → INFO` (was filling disk). `MusicAssistant` restart policy `unless-stopped → always` (consistent with everything else). Added a do-not-touch comment to AMP's `mac_address` (licence-bound).
- **clean up per-machine .vscode settings and add .gitignore** — old `.vscode/settings.json` had hardcoded `c:\Users\o\...` paths to local Sentinel extension versions; deleted. Added a defensive `.gitignore` that excludes editor/IDE folders, OS files, local WG/SSH artifacts, and Pester scratch. **Crucially does NOT include `.env`** — those stay tracked because the `#{TOKEN}#` placeholder discipline depends on it (verified all 10 stack `.env` files are unaffected by the new ignore patterns).
- **fix typos in README templates** — `.env` template used YAML colon syntax (`MYSECRET:`) in a section labelled as `.env`; docker-compose template referenced a stale `autogen` router name in the middlewares line where it should have used `{containername}` like everywhere else.

## Pre-merge requirements

- ✅ **`NAS_HOST_KEY` secret added** to the `nas` environment (done as part of this work — verified via `gh secret list --env nas`)
- ✅ All commits green on validation
- ✅ `actionlint` clean on both workflows

## What this PR doesn't tackle (intentionally)

Two architectural items deferred to follow-up sessions:

1. **`:latest` image pinning + Watchtower strategy** — needs a real discussion about which strategy fits best (pin load-bearing only with Watchtower exclusion vs. pin everything with Renovate). Touches ~25 image references across all stacks.
2. **Reducing `privileged: true` on HomeAssistant, NodeRed, Frigate, SnapRAID** — needs a live test cycle on the NAS to discover the actual capabilities each container needs. Better done with HA/Frigate UIs open to watch for permission errors.

## Deploy-time impact

When this merges, the deploy pipeline will recreate the following containers (due to spec changes — labels, restart policy, command args):
- **Netdata, Plex, MusicAssistant, AdGuardHome-Sync, FileBrowser, Tdarr, Wrapperr, AMP, Traefik**

Only **Netdata** has a meaningfully different runtime behaviour: its history will start persisting properly (the `/varl/` typo meant nothing was being persisted before).
