### PR TITLE
fix: limit compose parallelism to 3 to work around NAS sshd MaxSessions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,20 @@ jobs:
       # STEP - Deploy Stacks
       # ====================
       # Deploy docker stacks locally
+      #
+      # COMPOSE_PARALLEL_LIMIT=3 caps how many container operations Compose
+      # runs simultaneously per stack. The remote Docker daemon is reached
+      # over SSH, and the NAS's sshd has the default MaxSessions=10. With
+      # the previous unlimited parallelism, the media stack (13 services)
+      # blew past that cap and failed with:
+      #   "Session open refused by peer"
+      # 3 keeps simultaneous SSH channels comfortably below 10 even
+      # accounting for the 2-3 channels each Compose action opens
+      # (container query + image manifest + start). Bump cautiously if
+      # stacks grow much larger, or raise NAS sshd MaxSessions instead.
       - name: Deploy Docker Stacks
+        env:
+          COMPOSE_PARALLEL_LIMIT: 3
         run: |
           set -eo pipefail
           failed=()


### PR DESCRIPTION
## What

Adds `COMPOSE_PARALLEL_LIMIT: 3` to the Deploy Docker Stacks step env.

## Why

Deploy has been failing every run since ~May 24 with:

```
error during connect: Post "http://docker.example.com/v1.51/containers/.../start":
  command [ssh -o ConnectTimeout=30 -T -l *** -- *** docker system dial-stdio]
  has exited with exit status 255,
  stderr=mux_client_request_session: session request failed: Session open refused by peer
```

Always on the same stack (`media`), same error. Last successful deploy was 3 May (the one that added MusicAssistant as the 13th media service).

### Root cause

The NAS's `sshd_config` doesn't set `MaxSessions`, so it uses the OpenSSH default of **10**. The remote Docker daemon is reached over SSH, and each Compose action (state query, image manifest, container start) opens its own SSH session. With 13 services in the media stack running operations in parallel, sshd refuses session #11 and the operation fails.

Other stacks have <10 services so they never hit the cap — but the previous silent-failure loop made it look like deploy was completely broken. PR #78's loud-failure loop revealed only `media` was actually failing.

### Why `COMPOSE_PARALLEL_LIMIT=3`

Each parallel compose action opens 2-3 SSH channels worth of concurrent state. Math:

| `COMPOSE_PARALLEL_LIMIT` | Worst-case simultaneous channels | Headroom vs 10 |
|---|---|---|
| (default unlimited) | 13+ | ❌ always fails |
| 5 | 5–15 | ⚠️ borderline |
| **3** | **3–9** | **✅ safe** |
| 1 | 1–3 | ✅ safe but slow |

3 gives ~3x the speedup of sequential while staying comfortably under the cap even if a stack grows.

## Trade-off

Media stack deploy gets ~1–2 minutes slower because containers are recreated in batches of 3 instead of all at once. Other stacks unaffected (all already had <10 services).

## Alternative considered

Raising `MaxSessions` on the NAS sshd (e.g. to 25 via `/etc/ssh/sshd_config.d/99-docker-context.conf`). Would fix this for any future SSH-based automation too, but it's a host config change outside this repo's scope. Worth doing in the ansible host-provisioning repo as a follow-up.

## Verification

- ✅ actionlint clean
- ✅ Validation will run on push (no compose changes — should be no-op pass)
- ⏳ Deploy verification requires merge — will be observable in the merge run
