### PR TITLE
fix: drop rsync -t (preserve mtimes) to fix directory permission errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,11 +163,18 @@ jobs:
       #'ai/') are removed on the NAS, not orphaned forever. Excludes
       #repo-meta dirs (.git, .github, .vscode) and the wireguard config
       #we used for this run (belt-and-braces; we already rm'd it).
+      #
+      #-rlpgoD instead of -a: drops -t (preserve mtimes) because the
+      #stack directories on the NAS are owned by root, but we connect
+      #as owen. Only inode owners (or root) can update directory mtimes,
+      #so -t fails with 'Operation not permitted' even though the file
+      #content sync succeeds. Without -t, dir mtimes reflect "last
+      #deploy time" which is more useful here anyway.
       - name: Copy Content Locally
         run: |
           #cleanup working files
           rm ./wg0.conf
-          rsync -avz --delete \
+          rsync -rlpgoDvz --delete \
             --exclude='.git' --exclude='.github' --exclude='.vscode' \
             --exclude='wg0.conf' \
             ./ ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks/


### PR DESCRIPTION
## What

Replaces `rsync -a` with `rsync -rlpgoD` in the Copy Content Locally step (drops the `-t` / preserve-mtimes flag).

## Why

After PR #82's parallel-limit fix unblocked the actual stack deploys, the Copy Content Locally step started failing with:

```
rsync: [generator] failed to set times on "/config/stacks/games": Operation not permitted (1)
rsync: [generator] failed to set times on "/config/stacks/homeautomation": Operation not permitted (1)
... (and so on for misc, monitor, network, proxy, security)
rsync error: some files/attrs were not transferred (see previous errors) (code 23)
```

**File content transferred fine** — the failure is rsync trying to update directory mtimes after the file writes complete.

### Root cause

`/config/stacks/*` directories on the NAS are owned by `root:root` (legacy from earlier deploys before the workflow was set up consistently). The workflow connects as `owen`, who has rwx via POSIX ACL but not ownership of the inode. Only the inode owner (or root) can call `utimes()` on a directory, so `-t` fails with EPERM.

The file writes themselves work because owen has w via the ACL, and creating/updating files inside a directory doesn't need to own the directory.

### Why `-rlpgoD`

`-a` expands to `-rlptgoD`. Just removing `-t` (mtimes) keeps:
- `-r` recursive
- `-l` preserve symlinks
- `-p` preserve perms
- `-g` preserve group
- `-o` preserve owner
- `-D` preserve devices

So perms/owner/group still flow through. Just mtimes change to "deploy time" instead of "source mtime", which is arguably more useful here anyway.

## Alternatives considered

- **`rsync -rvz --no-perms --no-owner --no-group --no-times`** — works but drops too much. We lose perm-info preservation, which means a fresh NAS rebuild wouldn't get sensible initial perms from this rsync.
- **`sudo chown -R owen:owen /config/stacks` on the NAS** — would let us keep `-a`, but that's an undocumented out-of-repo fix that gets re-broken on NAS rebuild. Could still do this as belt-and-braces, but the in-repo fix shouldn't depend on it.

## Verification

- ✅ actionlint clean
- ⏳ Real test on merge — should see Copy Content Locally succeed this time
