### PR TITLE
fix: drop ALL rsync metadata flags (perms/owner/group/times), not just times

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,17 +164,24 @@ jobs:
       #repo-meta dirs (.git, .github, .vscode) and the wireguard config
       #we used for this run (belt-and-braces; we already rm'd it).
       #
-      #-rlpgoD instead of -a: drops -t (preserve mtimes) because the
-      #stack directories on the NAS are owned by root, but we connect
-      #as owen. Only inode owners (or root) can update directory mtimes,
-      #so -t fails with 'Operation not permitted' even though the file
-      #content sync succeeds. Without -t, dir mtimes reflect "last
-      #deploy time" which is more useful here anyway.
+      #Why -rlvz + --no-perms/owner/group/times instead of -a:
+      #The /config/stacks/* directories on the NAS are owned by root.
+      #We connect as owen (rwx via POSIX ACL but not the inode owner).
+      #Only the inode owner (or root) can update directory metadata
+      #(chmod, chown, chgrp, utimes), so every flag in -a that touches
+      #directory metadata fails with 'Operation not permitted' — both
+      #-t (PR #83 dropped this) and -p (still failing). Rather than
+      #removing flags one error at a time, just drop ALL metadata
+      #preservation. We only care about file content here; the NAS
+      #already has correct dir perms from earlier setup, and new files
+      #get sensible defaults (umask 022 -> 644). No executable scripts
+      #in this repo so dropping perms is safe.
       - name: Copy Content Locally
         run: |
           #cleanup working files
           rm ./wg0.conf
-          rsync -rlpgoDvz --delete \
+          rsync -rlvz --delete \
+            --no-perms --no-owner --no-group --no-times \
             --exclude='.git' --exclude='.github' --exclude='.vscode' \
             --exclude='wg0.conf' \
             ./ ${{ secrets.NAS_USER }}@${{ secrets.NAS_IP }}:/config/stacks/


### PR DESCRIPTION
## What

Replaces `rsync -rlpgoDvz` (PR #83's incremental fix) with `rsync -rlvz + --no-perms --no-owner --no-group --no-times` to drop **all** metadata preservation that requires inode ownership.

## Why PR #83 wasn't enough

PR #83 dropped `-t` after seeing `failed to set times`. The next deploy failed with the same EPERM at a different syscall:

```
rsync: [generator] failed to set permissions on "/config/stacks/.": Operation not permitted (1)
rsync: [generator] failed to set permissions on "/config/stacks/games": Operation not permitted (1)
... (same for every stack dir)
rsync error: some files/attrs were not transferred (code 23)
```

My bad on PR #83 — I treated the symptom (mtime failure) instead of the root cause (no ownership = no metadata writes of any kind).

## Root cause (unchanged from PR #83)

`/config/stacks/*` directories on the NAS are owned by `root:root`. The workflow connects as `owen` (rwx via POSIX ACL, but not the inode owner). Any metadata-changing syscall on those directories (`chmod`, `chown`, `chgrp`, `utimes`) requires either ownership or root — owen has neither, so they all fail with EPERM.

`-a` shorthand = `-rlptgoD`. Of those: `-p`, `-t`, `-g`, `-o` all touch directory metadata. So they all fail. Removing flags one at a time (PR #83 removed `-t`, this PR removes `-p`/`-o`/`-g`) would be slow theatre. Just drop them all now.

## What's still preserved

| Flag | Purpose | Kept? |
|---|---|---|
| `-r` | recursive | ✅ |
| `-l` | preserve symlinks | ✅ |
| `-v` | verbose (for log output) | ✅ |
| `-z` | compress transfer | ✅ |
| `--delete` | remove orphans | ✅ |

## What's dropped

- `-p` perms: new files get default umask perms (`644`). **Safe** — checked `find . -type f -perm -u+x` returns no results, so no executable scripts in the repo depend on perm preservation. Existing perms on the NAS stay as-is.
- `-t` mtimes: file/dir mtimes will reflect deploy time, not source time. **Arguably more useful** for a deploy-target mirror.
- `-o` owner / `-g` group: new files owned by `owen:owen` (deploy user). Existing dirs keep their `root:root` ownership.
- `-D` devices/special: irrelevant — we don't have any in the repo.

## Verification

- ✅ actionlint clean
- ✅ Flag combination test-ran on the NAS (`rsync -rlvz --delete --no-perms --no-owner --no-group --no-times` against test paths) — accepted and works as expected
- ⏳ Real verification on merge — should see Copy Content Locally finally succeed

## Belt-and-braces alternative

Could also `chown -R owen:owen /config/stacks` on the NAS to fix this at the source. Worth considering for the future Ansible host-provisioning repo so a fresh NAS rebuild gets sensible ownership. But the in-repo fix here doesn't *require* it.
