### PR TITLE
fix(storage): correct PBS uptime-monitor URL to its own host

### DIFF
--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     - traefik.http.routers.pbs.middlewares=Real-IP@file, Headers@file
     # AutoKuma - Uptime Kuma Monitor
     - kuma.pbs.http.name=pbs
-    - kuma.pbs.http.url=https://crashplan.${DOMAIN}
+    - kuma.pbs.http.url=https://pbs.${DOMAIN}
     - kuma.pbs.http.headers=${KUMA_CFHEADERS}
     - kuma.pbs.http.parent_name=storage
 


### PR DESCRIPTION
## Summary

The PBS service (added in #95) has an AutoKuma monitor URL that was copied from the CrashPlan service and never updated:

```diff
-    - kuma.pbs.http.url=https://crashplan.${DOMAIN}
+    - kuma.pbs.http.url=https://pbs.${DOMAIN}
```

The new value matches PBS's own Traefik router rule (`Host(\`pbs.${DOMAIN}\`)`).

## Why it matters

* The **`pbs` uptime monitor was actually probing CrashPlan** — so PBS could be down while Uptime Kuma showed it green (false-negative on a *backup* service, the worst kind to be blind on).
* **CrashPlan was being double-monitored** by both `kuma.crashplan` and `kuma.pbs`.

## Scope

* One line in `storage/docker-compose.yml`. CrashPlan's own labels are untouched.
* No secrets, no image changes, no `.env` changes.

## Test plan

* [x] CrashPlan labels still reference `crashplan.${DOMAIN}` (unchanged)
* [x] PBS `kuma.pbs.http.url` now matches its Traefik `routers.pbs.rule` host
* [ ] VALIDATION workflow (`docker compose config -q`) passes on this branch
* [ ] After merge → DEPLOY redeploys storage stack; confirm AutoKuma recreates the `pbs` monitor pointing at `pbs.${DOMAIN}`

🦚 _Filed by Argus._
